### PR TITLE
Parallel chunk.apply support.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: iotools
-Version: 0.1-4
+Version: 0.1-5
 Title: I/O tools for streaming
 Author: Simon Urbanek <Simon.Urbanek@r-project.org>, Taylor Arnold <taylor.arnold@acm.org>
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>

--- a/R/stream.R
+++ b/R/stream.R
@@ -132,7 +132,11 @@ mc.chunk.apply = function(input, FUN, ..., CH.MERGE, CH.MAX.SIZE,
     worker_queue[[i]] = mcparallel(FUN(chunk, ...))
   }
   if (length(worker_queue) == 0) return(CH.MERGE(NULL))
-
+ 
+  # If CH.MERGE is list, override it with the correct CH.MERGE function.
+  if (identical(list, CH.MERGE))
+    CH.MERGE = function(x, ...) c(x, list(...))
+    
   # Pre-fetch the next chunk if we not at the end of input.
   if (length(chunk) > 0) chunk = read.chunk(reader)
 

--- a/R/stream.R
+++ b/R/stream.R
@@ -96,8 +96,6 @@ chunk.apply <- function(input, FUN, ..., CH.MERGE=rbind, CH.MAX.SIZE=33554432,
                            CH.MAX.SIZE=CH.MAX.SIZE, frame=parent.frame()))
   # Multiple processes have been specified.
   if (.Platform$OS.type != "unix") {
-    warning(paste("Parallel chunk.apply only work on unix platforms.",
-                  "Running sequentially"))
     return(seq.chunk.apply(input, FUN, ..., CH.MERGE=CH.MERGE, 
                            CH.MAX.SIZE=CH.MAX.SIZE, frame=parent.frame()))
   }

--- a/R/stream.R
+++ b/R/stream.R
@@ -92,26 +92,28 @@ chunk.apply <- function(input, FUN, ..., CH.MERGE=rbind, CH.MAX.SIZE=33554432,
   if (parallel < 1)
     stop("You must specify a postive integer number of parallel processes")
   if (parallel == 1) 
-    return(seq.chunk.apply(input, FUN, ..., CH.MERGE, CH.MAX.SIZE))
+    return(seq.chunk.apply(input, FUN, ..., CH.MERGE=CH.MERGE, 
+                           CH.MAX.SIZE=CH.MAX.SIZE, frame=parent.frame()))
   # Multiple processes have been specified.
   if (.Platform$OS.type != "unix") {
     warning(paste("Parallel chunk.apply only work on unix platforms.",
                   "Running sequentially"))
-    return(seq.chunk.apply(input, FUN, ..., CH.MERGE, CH.MAX.SIZE))
+    return(seq.chunk.apply(input, FUN, ..., CH.MERGE=CH.MERGE, 
+                           CH.MAX.SIZE=CH.MAX.SIZE, frame=parent.frame()))
   }
-  mc.chunk.apply(input, FUN, ..., CH.MERGE, CH.MAX.SIZE, parallel)
+  mc.chunk.apply(input, FUN, ..., CH.MERGE=CH.MERGE, 
+                 CH.MAX.SIZE=CH.MAX.SIZE, mc.cores=parallel)
 }
 
-seq.chunk.apply <- function(input, FUN, ..., CH.MERGE=rbind, 
-                            CH.MAX.SIZE=33554432) {
+seq.chunk.apply <- function(input, FUN, ..., CH.MERGE, CH.MAX.SIZE, frame) {
   if (!inherits(input, "ChunkReader"))
     reader <- chunk.reader(input)
-  .Call(chunk_apply, reader, CH.MAX.SIZE, CH.MERGE, FUN, parent.frame(), .External(pass, ...))
+  .Call(chunk_apply, reader, CH.MAX.SIZE, CH.MERGE, FUN, frame, 
+        .External(pass, ...))
 }
 
-mc.chunk.apply = function(input, FUN, ..., CH.MERGE=rbind, 
-                          CH.MAX.SIZE= 33554432, 
-                          mc.cores=getOption("mc.cores", 2L)) {
+mc.chunk.apply = function(input, FUN, ..., CH.MERGE, CH.MAX.SIZE, 
+                          mc.cores) {
   require(parallel)
   if (!inherits(input, "ChunkReader"))
     reader = chunk.reader(input)

--- a/man/chunk.apply.Rd
+++ b/man/chunk.apply.Rd
@@ -8,7 +8,8 @@
   to each chunk, collecting the results.
 }
 \usage{
-chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432, parallel=1)
+chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432, 
+            parallel=1)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{

--- a/man/chunk.apply.Rd
+++ b/man/chunk.apply.Rd
@@ -8,7 +8,7 @@
   to each chunk, collecting the results.
 }
 \usage{
-chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432)
+chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432, parallel=1)
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
@@ -21,6 +21,7 @@ chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432)
   behavior, \code{rbind} for table-like output or \code{c} for a long
   vector.}
   \item{CH.MAX.SIZE}{maximal size of each chunk in bytes}
+  \item{parallel}{number of parallel processes to use (unix only)}
 }
 \note{
   The input to \code{FUN} is the raw chunk, so typically it is
@@ -33,7 +34,7 @@ chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432)
 %\references{
 %}
 \author{
- Simon Urbanek
+ Simon Urbanek and Michael Kane
 }
 %\note{
 %}


### PR DESCRIPTION
1. chunk.apply now dispatches to either the seq.chunk.apply or mc.chunk.apply function. Both are private.
2. There is a new "parallel" parameter for chunk.apply. The default is 1. If more than 1 is specified an you are on a unix machine the chunk.apply occurs in parallel and chunks are pre-fetched.
3. The documentation has been updated to reflect the new parameter.
4. The minor version has been bumped.