### PR TITLE
Pipeline parallel chunk.apply

### DIFF
--- a/R/stream.R
+++ b/R/stream.R
@@ -1,51 +1,41 @@
 chunk.apply <- function(input, FUN, ..., CH.MERGE=rbind, CH.MAX.SIZE=33554432,
-                        parallel=1, pipeline=TRUE) {
+                        parallel=1) {
   if (!inherits(input, "ChunkReader"))
     reader <- chunk.reader(input)
   if (parallel <= 1 || .Platform$OS.type != "unix") {
     return(.Call(chunk_apply, reader, CH.MAX.SIZE, CH.MERGE, FUN, 
                  parent.frame(), .External(pass, ...)))
   } else {
-    require(parallel)
-    ret=NULL
-    done=FALSE
+    library(parallel)
+
     # If CH.MERGE is list, override it with the correct CH.MERGE function.
     if (identical(list, CH.MERGE)) CH.MERGE = function(x, ...) c(x, list(...))
 
-    if (pipeline) {
-      worker_queue = list()
+    worker_queue = list()
+    # Fill the worker queue.
+    for (i in 1:max(parallel, 1)) {
+      chunk = read.chunk(reader)
+      if (length(chunk) == 0) {
+        break
+      }
+      worker_queue[[i]] = mcparallel(FUN(chunk, ...))
+    }
+    if (length(worker_queue) == 0) return(CH.MERGE(NULL))
 
-      # Fill the worker queue.
-      for (i in 1:max(parallel, 1)) {
+    # Pre-fetch the next chunk if we not at the end of input.
+    if (length(chunk) > 0) chunk = read.chunk(reader)
+
+    # Process the chunk-stream.
+    ret=NULL
+    done=FALSE
+    while (!done) {
+      ret = CH.MERGE(ret, mccollect(worker_queue[[1]])[[1]])
+      worker_queue[1] = NULL
+      if (length(chunk) > 0) {
+        worker_queue[[length(worker_queue)+1]] = mcparallel(FUN(chunk, ...))
         chunk = read.chunk(reader)
-        if (length(chunk) == 0) {
-          break
-        }
-        worker_queue[[i]] = mcparallel(FUN(chunk, ...))
       }
-      if (length(worker_queue) == 0) return(CH.MERGE(NULL))
-
-
-      # Pre-fetch the next chunk if we not at the end of input.
-      if (length(chunk) > 0) chunk = read.chunk(reader)
-
-      # Process the chunk-stream.
-      while (!done) {
-        ret = CH.MERGE(ret, mccollect(worker_queue[[1]])[[1]])
-        worker_queue[1] = NULL
-        if (length(chunk) > 0) {
-          worker_queue[[length(worker_queue)+1]] = mcparallel(FUN(chunk, ...))
-          chunk = read.chunk(reader)
-        }
-        if (length(worker_queue) == 0) done = TRUE
-      }
-    } else {
-      chunks = list()
-      while(!done) {
-        for (i in 1:parallel) chunks[[i]] = read.chunk(reader)
-        if (any(unlist(lapply(chunks, length)) == 0)) done=TRUE
-        ret = CH.MERGE(ret, mclapply(chunks, FUN, mc.cores=parallel))
-      }
+      if (length(worker_queue) == 0) done = TRUE
     }
     return(ret)
   }

--- a/R/stream.R
+++ b/R/stream.R
@@ -1,7 +1,54 @@
-chunk.apply <- function(input, FUN, ..., CH.MERGE=rbind, CH.MAX.SIZE=33554432) {
+chunk.apply <- function(input, FUN, ..., CH.MERGE=rbind, CH.MAX.SIZE=33554432,
+                        parallel=1, pipeline=TRUE) {
   if (!inherits(input, "ChunkReader"))
     reader <- chunk.reader(input)
-  .Call(chunk_apply, reader, CH.MAX.SIZE, CH.MERGE, FUN, parent.frame(), .External(pass, ...))
+  if (parallel <= 1 || .Platform$OS.type != "unix") {
+    return(.Call(chunk_apply, reader, CH.MAX.SIZE, CH.MERGE, FUN, 
+                 parent.frame(), .External(pass, ...)))
+  } else {
+    require(parallel)
+    ret=NULL
+    done=FALSE
+    # If CH.MERGE is list, override it with the correct CH.MERGE function.
+    if (identical(list, CH.MERGE)) CH.MERGE = function(x, ...) c(x, list(...))
+
+    if (pipeline) {
+      worker_queue = list()
+
+      # Fill the worker queue.
+      for (i in 1:max(parallel, 1)) {
+        chunk = read.chunk(reader)
+        if (length(chunk) == 0) {
+          break
+        }
+        worker_queue[[i]] = mcparallel(FUN(chunk, ...))
+      }
+      if (length(worker_queue) == 0) return(CH.MERGE(NULL))
+
+
+      # Pre-fetch the next chunk if we not at the end of input.
+      if (length(chunk) > 0) chunk = read.chunk(reader)
+
+      # Process the chunk-stream.
+      while (!done) {
+        ret = CH.MERGE(ret, mccollect(worker_queue[[1]])[[1]])
+        worker_queue[1] = NULL
+        if (length(chunk) > 0) {
+          worker_queue[[length(worker_queue)+1]] = mcparallel(FUN(chunk, ...))
+          chunk = read.chunk(reader)
+        }
+        if (length(worker_queue) == 0) done = TRUE
+      }
+    } else {
+      chunks = list()
+      while(!done) {
+        for (i in 1:parallel) chunks[[i]] = read.chunk(reader)
+        if (any(unlist(lapply(chunks, length)) == 0)) done=TRUE
+        ret = CH.MERGE(ret, mclapply(chunks, FUN, mc.cores=parallel))
+      }
+    }
+    return(ret)
+  }
 }
 
 chunk.tapply <- function(input, FUN, ..., sep='\t', CH.MERGE=rbind, CH.MAX.SIZE=33554432) {

--- a/man/chunk.apply.Rd
+++ b/man/chunk.apply.Rd
@@ -9,7 +9,7 @@
   to each chunk, collecting the results.
 }
 \usage{
-chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432)
+chunk.apply(input, FUN, ..., CH.MERGE = rbind, CH.MAX.SIZE = 33554432, parallel=1)
 
 chunk.tapply(input, FUN, ..., sep = "\t", CH.MERGE = rbind, CH.MAX.SIZE = 33554432)
 }
@@ -27,6 +27,7 @@ chunk.tapply(input, FUN, ..., sep = "\t", CH.MERGE = rbind, CH.MAX.SIZE = 335544
   behavior, \code{rbind} for table-like output or \code{c} for a long
   vector.}
   \item{CH.MAX.SIZE}{maximal size of each chunk in bytes}
+  \item{parallel}{the number of parallel processes to use in the calculation (*nix only).}
 }
 \note{
   The input to \code{FUN} is the raw chunk, so typically it is


### PR DESCRIPTION
Pipeline parallelism has been added to chunk.apply. Per Simon U's suggestions:
* chunk.apply does not dispatch to a sequential and parallel version of chunk.apply.
* If you are on Windows and chunk.apply's parallel parameter is not one chunk.apply runs sequentially without a warning.

Please let me know if there are other changes that should be made.