### PR TITLE
Supporting tab/comma separated files with as.output when x is a data.frame or matrix

### DIFF
--- a/R/output.R
+++ b/R/output.R
@@ -1,7 +1,30 @@
 as.output <- function(x, ...) UseMethod("as.output")
 as.output.default <- function(x, ...) if (is.null(names(x))) as.character(x) else paste(names(x), as.character(x), sep='\t')
 as.output.table <- function(x, ...) paste(names(x), x, sep='\t')
-as.output.matrix <- function(x, ...) { o <- apply(x, 1, paste, collapse='|'); if (!is.null(rownames(x))) o <- paste(rownames(x), o, sep='\t'); o }
+as.output.matrix <- function(x, sep, ...) { 
+  if (missing(sep)) {
+    key_sep = '|'
+    field_sep = '\t'
+  } else {
+    key_sep = field_sep = sep
+  }
+  o <- apply(x, 1, paste, collapse=key_sep)
+  if (!is.null(rownames(x))) 
+    o <- paste(rownames(x), o, sep=field_sep)
+  o 
+}
 as.output.list <- function(x, ...) paste(names(x), sapply(x, function (e) paste(as.character(e), collapse='|')), sep='\t')
-as.output.data.frame <- function(x, ...) { if (ncol(x) == 1L) return(as.character(x[,1])); o <- apply(x[,-1,drop=FALSE], 1, paste, collapse='|'); o <- paste(x[,1], o, sep='\t'); o }
+as.output.data.frame <- function(x, sep, ...) { 
+  if (ncol(x) == 1L) 
+    return(as.character(x[,1]))
+  if (missing(sep)) {
+    key_sep = '|'
+    field_sep = '\t'
+  } else {
+    key_sep = field_sep = sep
+  }
+  o <- apply(x[,-1,drop=FALSE], 1, paste, collapse=key_sep)
+  o <- paste(x[,1], o, sep=field_sep)
+  o 
+}
 

--- a/man/asoutput.Rd
+++ b/man/asoutput.Rd
@@ -12,12 +12,13 @@
   Create objects of class \code{output}.
 }
 \usage{
-  as.output(x, ...)
+  as.output(x, sep='\t', ...)
 }
 \arguments{
   \item{x}{object to be converted to an instance of \code{output}.}
   \item{...}{optional arguments to be passed to implementing methods
-  of \code{as.output}}
+  of \code{as.output}. For \code{matrix}, and \code{data.frame} 
+  types this includes a \code{sep} argument indicating a field separator.}
 }
 \details{
   \code{as.output} is generic, and methods can be written to support

--- a/man/asoutput.Rd
+++ b/man/asoutput.Rd
@@ -12,7 +12,7 @@
   Create objects of class \code{output}.
 }
 \usage{
-  as.output(x, sep='\t', ...)
+  as.output(x, ...)
 }
 \arguments{
   \item{x}{object to be converted to an instance of \code{output}.}


### PR DESCRIPTION
I've added an optional ```sep``` argument to ```as.output.matrix``` and ```as.output.data.frame```. If it is not specified everything works as it currently does. If it is specified then both the key separator (currently ```"\t"```) and the field separator (currently ```"|"```) are set to the ```sep``` value. This will be helpful for writing tsv and csv files.