### PR TITLE
Windows support and continuous integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,11 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^data-raw$
+^README\.Rmd$
+^README-.*\.png$
+^\.travis\.yml$
+^CONDUCT\.md$
+^cran-comments\.md$
+^appveyor\.yml$
+^codecov\.yml$
+^codemeta\.json$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+sudo: false
+cache: packages
+r_packages:
+  - covr
+  - testthat
+after_success:
+  - Rscript -e 'covr::codecov()'
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: iotools
-Version: 0.2-4
+Version: 0.2-5
 Title: I/O Tools for Streaming
 Author: Simon Urbanek <Simon.Urbanek@r-project.org>, Taylor Arnold <taylor.arnold@acm.org>
 Maintainer: Simon Urbanek <Simon.Urbanek@r-project.org>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-### High-performance I/O tools for R
+High-performance I/O tools for R
+===
+
+**Maintainer:** Simon Urbanek<br/>
+**Authors:** Simon Urbanek and Taylor Arnold<br/>
+**Contributors:** Michael Kane
+
+[![Build Status](https://travis-ci.org/kaneplusplus/iotools.svg?branch=master)](https://travis-ci.org/kaneplusplus/iotools)
+[![Build status](https://ci.appveyor.com/api/projects/status/308d0abnnn6u4c4b?svg=true)](https://ci.appveyor.com/project/kaneplusplus/iotools)
 
 Anyone dealing with large data knows that stock tools in R are bad at
 loading (non-binary) data to R. This package started as an attempt to

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,42 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/cleanup
+++ b/cleanup
@@ -1,0 +1,3 @@
+rm -f src/Makevars
+rm -f src/*o
+

--- a/cleanup
+++ b/cleanup
@@ -1,3 +1,3 @@
+
 rm -f src/Makevars
 rm -f src/*o
-

--- a/configure.win
+++ b/configure.win
@@ -1,4 +1,4 @@
 
-FLAGS="-DWINDOWS ${FLAGS}"
+FLAGS="PKG_CPPFLAGS=-DWINDOWS"
 echo "${FLAGS}" > src/Makevars
 

--- a/configure.win
+++ b/configure.win
@@ -1,4 +1,4 @@
 
-FLAGS="${FLAGS} -DWINDOWS"
+FLAGS="-DWINDOWS ${FLAGS}""
 echo "${FLAGS}" > src/Makevars
 

--- a/configure.win
+++ b/configure.win
@@ -1,3 +1,4 @@
+
 FLAGS="${FLAGS} -DWINDOWS"
 echo "${FLAGS}" > src/Makevars
 

--- a/configure.win
+++ b/configure.win
@@ -1,5 +1,3 @@
 
-FLAGS="PKG_CPPFLAGS=-DWINDOWS"
-PKG_LIBS="PKG_LIBS=-lws2_32"
-echo "${FLAGS}" > src/Makevars
-echo "${PKG_LIBS}" >> src/Makevars
+# Link to unix compatible layer for selects.
+echo "PKG_LIBS=-lws2_32" > src/Makevars

--- a/configure.win
+++ b/configure.win
@@ -1,0 +1,3 @@
+FLAGS="${FLAGS} -DWINDOWS"
+echo "${FLAGS}" > src/Makevars
+

--- a/configure.win
+++ b/configure.win
@@ -1,4 +1,4 @@
 
-FLAGS="-DWINDOWS ${FLAGS}""
+FLAGS="-DWINDOWS ${FLAGS}"
 echo "${FLAGS}" > src/Makevars
 

--- a/configure.win
+++ b/configure.win
@@ -1,4 +1,5 @@
 
 FLAGS="PKG_CPPFLAGS=-DWINDOWS"
+PKG_LIBS="PKG_LIBS=-lws2_32"
 echo "${FLAGS}" > src/Makevars
-
+echo "${PKG_LIBS}" >> src/Makevars

--- a/src/lnchunk.c
+++ b/src/lnchunk.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #ifdef WINDOWS
+  #define INCL_WINSOCK_API_PROTOTYPES
   #include <winsock2.h> 
 #else
   #include <sys/select.h>

--- a/src/lnchunk.c
+++ b/src/lnchunk.c
@@ -5,7 +5,6 @@
 #include <errno.h>
 #include <time.h>
 #include <unistd.h>
-#include <sys/select.h>
 
 #include <Rinternals.h>
 #include <Rversion.h>

--- a/src/lnchunk.c
+++ b/src/lnchunk.c
@@ -5,7 +5,12 @@
 #include <errno.h>
 #include <time.h>
 #include <unistd.h>
-#include <winsock2.h> //#include <sys/select.h>
+
+#ifdef WINDOWS
+  #include <winsock2.h> 
+#else
+  #include <sys/select.h>
+#endif
 
 #include <Rinternals.h>
 #include <Rversion.h>

--- a/src/lnchunk.c
+++ b/src/lnchunk.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 #include <time.h>
 #include <unistd.h>
-#include <sys/select.h>
+#include <winsock2.h> //#include <sys/select.h>
 
 #include <Rinternals.h>
 #include <Rversion.h>

--- a/src/lnchunk.c
+++ b/src/lnchunk.c
@@ -5,6 +5,7 @@
 #include <errno.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/select.h>
 
 #include <Rinternals.h>
 #include <Rversion.h>

--- a/src/lnchunk.c
+++ b/src/lnchunk.c
@@ -6,7 +6,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef WINDOWS
+#ifdef WIN32
   #define INCL_WINSOCK_API_PROTOTYPES
   #include <winsock2.h> 
 #else


### PR DESCRIPTION
Windows support was added by
1. Checking to see if the build is Windows. A "WINDOWS" macro is created in configure.win.
2. Enabling Windows and Unix system call compatibility (#define INCL_WINSOCK_API_PROTOTYPES)
3. Including the compatibility headers (#include <winsock2.h>).
4. Linking to the ws2_32 library.
5. Adding a cleanup script that removes Makevars and object files for windows.

In addition, the package was tested with continuous integration on both Linux and Windows. 

**Please note:** for CI to work on the merged branch you will need to set it up at [TravisCI](https://travis-ci.org) and [AppVeyor](https://ci.appveyor.com). Accounts for both are free and your Github account is compatible with both. Then the badge urls will have to be updated in README.md.