### PR TITLE
Updating chunk.map to support properly the max.size parameter

### DIFF
--- a/R/local.R
+++ b/R/local.R
@@ -167,7 +167,7 @@ chunk.map = function(input, output = NULL, formatter = .default.formatter,
   if (skip > 0L) readLines(input, n=skip)
   cr = chunk.reader(input, max.line = max.line, sep = key.sep)
 
-  while ( length(r <- read.chunk(cr)) ) {
+  while ( length(r <- read.chunk(cr, max.size = max.size)) ) {
     val = FUN(formatter(r), ...)
 
     if (!is.null(output)) {


### PR DESCRIPTION
Co-authored-by: gabrielfelipeg <gabriel.gomes@ccc.ufcg.edu.br>

We noticed that the `chunk.map` was ignoring the parameter `max.size` since it was not being passed to `read.chunk`, so the `read.chunk` was using its default value, and the read was limited to 32 MB.